### PR TITLE
chore(dora): exclude data imported from di

### DIFF
--- a/pipeline/dbt/models/intermediate/dora/int_dora__structures.sql
+++ b/pipeline/dbt/models/intermediate/dora/int_dora__structures.sql
@@ -31,6 +31,9 @@ final AS (
         NULLIF(city_code, '')      AS "code_insee",
         NULLIF(email, '')          AS "courriel"
     FROM structures
+    -- FIXME: exclude data that have been imported by dora from les emplois
+    --  because it decreases the average dataset quality.
+    WHERE source != 'di-emplois-de-linclusion'
 )
 
 SELECT * FROM final

--- a/pipeline/dbt/models/sources/dora/stg_dora__structures.sql
+++ b/pipeline/dbt/models/sources/dora/stg_dora__structures.sql
@@ -22,7 +22,8 @@ final AS (
         data ->> 'url'                                     AS "url",
         data ->> 'shortDesc'                               AS "short_desc",
         data ->> 'fullDesc'                                AS "full_desc",
-        data ->> 'linkOnSource'                            AS "link_on_source"
+        data ->> 'linkOnSource'                            AS "link_on_source",
+        data #>> '{source,value}'                          AS "source"
     FROM source
 )
 


### PR DESCRIPTION
le but est d'améliorer la qualité moyenne des données dora (pour soliguide notamment)

le mieux serait encore de voir avec l'équipe dora comment on peut identifier les données de qualité et mettre de côté tout ce qui a été généré par des imports et qui n'est pas affiché sur dora (car pas encore validé par porteur)