### PR TITLE
feat(api): nest structure in search results

### DIFF
--- a/api/src/data_inclusion/api/schema.py
+++ b/api/src/data_inclusion/api/schema.py
@@ -193,10 +193,6 @@ class Service(BaseModel):
         allow_population_by_field_name = True
 
 
-class ServiceSearchResult(Service):
-    distance: Optional[int]
-
-
 class Structure(BaseModel):
     # internal metadata
     di_geocodage_code_insee: Optional[constr(min_length=5, max_length=5)] = Field(
@@ -249,6 +245,11 @@ class Token(BaseModel):
 
 class DetailedService(Service):
     structure: Structure
+
+
+class ServiceSearchResult(BaseModel):
+    service: DetailedService
+    distance: Optional[int]
 
 
 class DetailedStructure(Structure):

--- a/api/tests/inclusion/test_api.py
+++ b/api/tests/inclusion/test_api.py
@@ -546,7 +546,7 @@ def test_list_services_filter_by_source(api_client, service_factory):
 @pytest.mark.with_token
 def test_list_services_filter_by_thematique(api_client, service_factory):
     service_1 = service_factory(
-        source="alpha",
+        structure__source="alpha",
         id="1",
         thematiques=[
             schema.Thematique.MOBILITE.value,
@@ -554,7 +554,7 @@ def test_list_services_filter_by_thematique(api_client, service_factory):
         ],
     )
     service_2 = service_factory(
-        source="alpha",
+        structure__source="alpha",
         id="2",
         thematiques=[
             schema.Thematique.TROUVER_UN_EMPLOI.value,
@@ -597,7 +597,7 @@ def test_list_services_filter_by_thematique(api_client, service_factory):
 @pytest.mark.with_token
 def test_list_services_filter_by_categorie_thematique(api_client, service_factory):
     service = service_factory(
-        source="alpha",
+        structure__source="alpha",
         id="1",
         thematiques=[
             schema.Thematique.MOBILITE__ACHETER_UN_VEHICULE_MOTORISE.value,
@@ -683,11 +683,11 @@ def test_search_services_with_code_insee(api_client, service_factory):
     assert response.status_code == 200
     resp_data = response.json()
     assert_paginated_response_data(resp_data, total=3)
-    assert resp_data["items"][0]["id"] == service_1.id
+    assert resp_data["items"][0]["service"]["id"] == service_1.id
     assert resp_data["items"][0]["distance"] == 0
-    assert resp_data["items"][1]["id"] == service_2.id
+    assert resp_data["items"][1]["service"]["id"] == service_2.id
     assert resp_data["items"][1]["distance"] == 40
-    assert resp_data["items"][2]["id"] == service_3.id
+    assert resp_data["items"][2]["service"]["id"] == service_3.id
     assert resp_data["items"][2]["distance"] is None
 
     response = api_client.get(url, params={"code_insee": "62041"})
@@ -714,8 +714,8 @@ def test_search_services_with_thematique(api_client, service_factory):
     assert response.status_code == 200
     resp_data = response.json()
     assert_paginated_response_data(resp_data, total=2)
-    assert resp_data["items"][0]["id"] in [service_1.id, service_2.id]
-    assert resp_data["items"][1]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][0]["service"]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][1]["service"]["id"] in [service_1.id, service_2.id]
 
     response = api_client.get(
         url,
@@ -746,8 +746,8 @@ def test_search_services_with_frais(api_client, service_factory):
     assert response.status_code == 200
     resp_data = response.json()
     assert_paginated_response_data(resp_data, total=2)
-    assert resp_data["items"][0]["id"] in [service_1.id, service_2.id]
-    assert resp_data["items"][1]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][0]["service"]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][1]["service"]["id"] in [service_1.id, service_2.id]
 
     response = api_client.get(
         url,
@@ -778,8 +778,8 @@ def test_search_services_with_types(api_client, service_factory):
     assert response.status_code == 200
     resp_data = response.json()
     assert_paginated_response_data(resp_data, total=2)
-    assert resp_data["items"][0]["id"] in [service_1.id, service_2.id]
-    assert resp_data["items"][1]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][0]["service"]["id"] in [service_1.id, service_2.id]
+    assert resp_data["items"][1]["service"]["id"] in [service_1.id, service_2.id]
 
     response = api_client.get(
         url,


### PR DESCRIPTION
format de réponse pour endpoint `/api/search/services` change en :

```json
[
  {
    "service": {
      ...
      "structure" : { ... }
      ...
    },
    "distance": 40,
  },
  ...
]
```

* `distance` n'est plus dans le service
* la structure est sérialisée dans le service
