### PR TITLE
fix(pipeline): Do not require 'frais' to be not null

### DIFF
--- a/pipeline/dbt/models/staging/sources/dora/_dora__models.yml
+++ b/pipeline/dbt/models/staging/sources/dora/_dora__models.yml
@@ -73,7 +73,7 @@ models:
           - dbt_utils.not_empty_string
       - name: frais
         tests:
-          - not_null
+          - dbt_utils.not_constant
           - relationships:
               to: ref('frais')
               field: value


### PR DESCRIPTION
The column is not required in the DORA datascheme in the database nor is enforced to be non null in the DORA API that exports the data to us.

Moreover, the 'frais' are also not mandatory in data-inclusion-schema, so everything points in the direction of the constraint to be lifted.

Cf. #141 