### PR TITLE
chore(root) : Fix docker-compose base environment values

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,10 @@ x-airflow-common:
     AIRFLOW_CONN_S3_SOURCES: ${AIRFLOW_CONN_S3_SOURCES}
 
     AIRFLOW_CONN_S3_LOGS: aws://@/data-inclusion-lake?endpoint_url=http%3A%2F%2Fminio%3A9000&aws_access_key_id=minioadmin&aws_secret_access_key=minioadmin
-    AIRFLOW__LOGGING__REMOTE_LOGGING: True
+    AIRFLOW__LOGGING__REMOTE_LOGGING: 'True'
     AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER: s3://data-inclusion-lake/logs
     AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID: s3_logs
-    AIRFLOW__LOGGING__DELETE_LOCAL_LOGS: True
+    AIRFLOW__LOGGING__DELETE_LOCAL_LOGS: 'True'
 
     # Variables
     AIRFLOW_VAR_DATAGOUV_API_KEY: ${AIRFLOW_VAR_DATAGOUV_API_KEY}


### PR DESCRIPTION
docker-compose up returns "contains true, which is an invalid type, it should be a string, number, or a null" in version 1.29.2.

The spec says :
https://github.com/compose-spec/compose-spec/blob/master/spec.md#environment

And indeed, in the map version (not the list in key=value) for the YAML properties, the `True` value must be quoted.

I don't really understand how it worked before, but maybe was it just a warning.